### PR TITLE
Adding custom modules imports

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -767,7 +767,7 @@ class StoryboardFile {
 
                     println()
                     println("//MARK: - \(customClass)")
-                    if let identifierExtenstionString = storyboardIdentifierExtenstion(viewController) {
+                    if let identifierExtenstionString = storyboardIdentifierExtension(viewController) {
                         println()
                         println(identifierExtenstionString)
                         println()
@@ -828,10 +828,15 @@ class StoryboardFile {
         }
     }
     
-    private func storyboardIdentifierExtenstion(viewController: XMLIndexer) -> String? {
+    private func storyboardIdentifierExtension(viewController: XMLIndexer) -> String? {
         var result:String? = nil
         if let customClass = viewController.element?.attributes["customClass"] {
             var output = String()
+            //check if the customModule belongs to the main application target, if so the import isn't necessary
+            let targetModule = viewController.element?.attributes["customModuleProvider"]
+            if let customModule = viewController.element?.attributes["customModule"] where targetModule == nil {
+                output += "import \(customModule)\n"
+            }
             output += "extension \(customClass) {\n"
             if let viewControllerId = viewController.element?.attributes["storyboardIdentifier"] {
                 output += "    override class var storyboardIdentifier:String? { return \"\(viewControllerId)\" }\n"


### PR DESCRIPTION
Check if view controller belongs to a custom Module and imports it if needed so that the project can compile. e.g.(AVPlayerViewController from AVKit needs the "import AVKit" line).

I'm also _fixign_ a typo.

TODO: For cosmetic purposes, we need to check for duplicated imports, but that requires a bigger refactor.
I would suggest that we could hold the output before printing it, for post processing string analysis (duplicated imports for instance). I'll write a issue to address that and further discussion.
