### PR TITLE
More convenient instantiating of View Controllers

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -840,8 +840,11 @@ class StoryboardFile {
             output += "extension \(customClass) {\n"
             if let viewControllerId = viewController.element?.attributes["storyboardIdentifier"] {
                 output += "    override class var storyboardIdentifier:String? { return \"\(viewControllerId)\" }\n"
+                output += "    class func instantiateFromStoryboard(storyboard: Storyboards) -> \(customClass)! {\n"
+                output += "        return storyboard.instantiateViewControllerWithIdentifier(self.storyboardIdentifier!) as? \(customClass)\n"
+                output += "    }\n"
             }
-            output += "}"
+            output += "}"            
             result = output
         }
         return result


### PR DESCRIPTION
Extension for view controllers with a known storyboard identifier that allows to instantiate view controller from specified storyboard;

It returns exact VC's subclass, so there is no need to make any casts after calling this method;

Before:

``` Swift
let myVC = Storyboards.Main.instantiateViewControllerWithIdentifier(CustomViewController.storyboardIdentifier!)
    as! CustomViewController
```

Now:

``` Swift
let myVC = CustomViewController.instantiateFromStoryboard(.Main)
```
