### PR TITLE
Fix naming of UITabBarController

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -707,7 +707,7 @@ enum OS: String, Printable {
             case "tableViewController":
                 return "UITableViewController"
             case "tabBarController":
-                return "UITabBarViewController"
+                return "UITabBarController"
             case "splitViewController":
                 return "UISplitViewController"
             case "pageViewController":


### PR DESCRIPTION
Unless I'm missing something, this should be `UITabBarController`?
