### PR TITLE
Parse ViewControllers that don't have a segue connected

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -868,7 +868,7 @@ class StoryboardFile {
             }
             output += "extension \(customClass) {\n"
             if let viewControllerId = viewController.element?.attributes["storyboardIdentifier"] {
-                output += "    override class var storyboardIdentifier:String? { return \"\(viewControllerId)\" }\n"
+                output += "    override class var storyboardIdentifier: String? { return \"\(viewControllerId)\" }\n"
                 output += "    class func instantiateFromStoryboard(storyboard: Storyboards) -> \(customClass)! {\n"
                 output += "        return storyboard.instantiateViewControllerWithIdentifier(self.storyboardIdentifier!) as? \(customClass)\n"
                 output += "    }\n"
@@ -995,7 +995,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     for controllerType in os.storyboardControllerTypes {
         println("//MARK: - \(controllerType) extension")
         println("extension \(controllerType) {")
-        println("    class var storyboardIdentifier:String? { return nil }")
+        println("    class var storyboardIdentifier: String? { return nil }")
         println("    func performSegue(segue: SegueProtocol, sender: AnyObject?) {")
         println("       performSegueWithIdentifier(segue.identifier, sender: sender)")
         println("    }")

--- a/natalie.swift
+++ b/natalie.swift
@@ -788,7 +788,9 @@ class StoryboardFile {
                         println("    }")
                         println("}")
                     }
-
+                }
+                
+                if let customClass = viewController.element?.attributes["customClass"] {
                     println()
                     println("//MARK: - \(customClass)")
                     if let identifierExtenstionString = storyboardIdentifierExtension(viewController) {
@@ -796,7 +798,10 @@ class StoryboardFile {
                         println(identifierExtenstionString)
                         println()
                     }
+                }
 
+                if let customClass = viewController.element?.attributes["customClass"],
+                    let segues = searchNamed(viewController, "segue")?.filter({ return $0.element?.attributes["identifier"] != nil }) {
                     if segues.count > 0 {
                         println("extension \(customClass) { ")
                         println()


### PR DESCRIPTION
Currently, it seems that only ViewControllers that have a Segue connected are parsed completely. Unfortunately, that behavior does not meet all requirements. 

I have a Storyboard that has several ViewController that are not connected via Segues and can only be accessed via their Storyboard Identifier. To support this, Natalie should create identifierExtensionStrings for those viewControllers.

I went ahead and changed the script to support this setup.

Additionally, I added two spaces that were missing.
