### PR TITLE
Added the ViewController Storyboard Identifiers to each storyboard

### DIFF
--- a/NatalieExample/NatalieExample/Storyboards.swift
+++ b/NatalieExample/NatalieExample/Storyboards.swift
@@ -6,24 +6,38 @@
 import UIKit
 
 //MARK: - Storyboards
-enum Storyboards: String {
-    case Main = "Main"
+struct Storyboards {
 
-    private var instance:UIStoryboard {
-        return UIStoryboard(name: self.rawValue, bundle: nil)
-    }
+    struct Main {
 
-    func instantiateInitialViewController() -> UIViewController? {
-        switch (self) {
-        case Main:
-            return self.instance.instantiateInitialViewController() as! UINavigationController
-        default:
-            return self.instance.instantiateInitialViewController() as? UIViewController
+        static let identifier = "Main"
+
+        static var storyboard:UIStoryboard {
+            return UIStoryboard(name: self.identifier, bundle: nil)
         }
-    }
 
-    func instantiateViewControllerWithIdentifier(identifier: String) -> UIViewController {
-        return self.instance.instantiateViewControllerWithIdentifier(identifier) as! UIViewController
+        static func instantiateInitialViewController() -> UINavigationController! {
+            return self.storyboard.instantiateInitialViewController() as! UINavigationController
+        }
+
+        static func instantiateViewControllerWithIdentifier(identifier: String) -> UIViewController {
+            return self.storyboard.instantiateViewControllerWithIdentifier(identifier) as! UIViewController
+        }
+
+        static func MainViewController() -> MainViewController! {
+            return self.storyboard.instantiateViewControllerWithIdentifier("MainViewController") as! MainViewController
+
+        }
+
+        static func ScreenTwoViewController() -> ScreenTwoViewController! {
+            return self.storyboard.instantiateViewControllerWithIdentifier("ScreenTwoViewController") as! ScreenTwoViewController
+
+        }
+
+        static func ScreenOneViewController() -> ScreenOneViewController! {
+            return self.storyboard.instantiateViewControllerWithIdentifier("ScreenOneViewController") as! ScreenOneViewController
+
+        }
     }
 }
 
@@ -58,21 +72,14 @@ extension UIViewController {
 extension UIStoryboardSegue: SegueProtocol {
 }
 
+
+//MARK: - MainViewController
 extension UIStoryboardSegue {
     func selection() -> MainViewController.Segue? {
         if let identifier = self.identifier {
             return MainViewController.Segue(rawValue: identifier)
         }
         return nil
-    }
-}
-
-//MARK: - MainViewController
-
-extension MainViewController {
-    override class var storyboardIdentifier:String? { return "MainViewController" }
-    class func instantiateFromStoryboard(storyboard: Storyboards) -> MainViewController! {
-        return storyboard.instantiateViewControllerWithIdentifier(self.storyboardIdentifier!) as? MainViewController
     }
 }
 
@@ -122,23 +129,6 @@ extension MainViewController {
 
 }
 
-
 //MARK: - ScreenTwoViewController
 
-extension ScreenTwoViewController {
-    override class var storyboardIdentifier:String? { return "ScreenTwoViewController" }
-    class func instantiateFromStoryboard(storyboard: Storyboards) -> ScreenTwoViewController! {
-        return storyboard.instantiateViewControllerWithIdentifier(self.storyboardIdentifier!) as? ScreenTwoViewController
-    }
-}
-
-
 //MARK: - ScreenOneViewController
-
-extension ScreenOneViewController {
-    override class var storyboardIdentifier:String? { return "ScreenOneViewController" }
-    class func instantiateFromStoryboard(storyboard: Storyboards) -> ScreenOneViewController! {
-        return storyboard.instantiateViewControllerWithIdentifier(self.storyboardIdentifier!) as? ScreenOneViewController
-    }
-}
-

--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ Since Natalie is a Swift script, that means it is written in Swift and requires 
 Generated enum Storyboards with convenient interface (drop-in replacement for UIStoryboard).
 
 ```swift
-enum Storyboards: String {
-    case Main = "Main"
-    case Second = "Second"
+struct Storyboards {
+    struct Main {...}
+    struct Second {...}
     ...
 ```
 
-Instantiate ViewController for storyboard
+Instantiate initial ViewController for storyboard
 ```swift
-let vc:MyViewController = Storyboards.Main.instantiateInitialViewController()
+let vc = Storyboards.Main.instantiateInitialViewController()
+```
+
+Instantiate ViewController in storyboard using storyboard id
+```swift
+let vc = Storyboards.Main.LoginVC()
 ```
 
 example usage for prepareForSegue()
@@ -46,18 +51,14 @@ self.performSegue(MyCustomViewController.Segue.goToDetails, sender:nil)
 
 Each custom view controller is extended with this code and provide list of available segues and additional informations from Storyboard.
 
-`storyboardIdentifier` is unique identifier of view controller in Storyboard
-
 `Segue` enumeration contains list of available segues
 
 `kind` property represent types Segue
 
-`destination` property return type of destinated view controller.
+`destination` property return type of destination view controller.
 
 ```swift
 extension MyCustomViewController { 
-    var storyboardIdentifier:String { return "oEB-rK-hJd" }
-
     enum Segue: String, Printable {
         case goToDetails = "goToDetails"
         case expandGroup = "composeMessage"

--- a/natalie.swift
+++ b/natalie.swift
@@ -1069,7 +1069,6 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     for controllerType in os.storyboardControllerTypes {
         println("//MARK: - \(controllerType) extension")
         println("extension \(controllerType) {")
-        println("    class var storyboardIdentifier:String? { return nil }")
         println("    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject?) {")
         println("       performSegueWithIdentifier(segue.identifier\(os.storyboardSegueUnwrap), sender: sender)")
         println("    }")

--- a/natalie.swift
+++ b/natalie.swift
@@ -824,25 +824,8 @@ class ViewController: XMLObject {
     lazy var customModule: String? = self.xml.element?.attributes["customModule"]
     
     
-    private func storyboardIdentifierExtension(os:OS) -> String? {
-        var result:String? = nil
-        if let customClass = self.customClass {
-            var output = String()
-            //check if the customModule belongs to the main application target, if so the import isn't necessary
-            if let customModule = self.customModule where self.customModuleProvider == nil {
-                output += "import \(customModule)\n"
-            }
-            output += "extension \(customClass) {\n"
-            if let viewControllerId = self.storyboardIdentifier {
-                output += "    override class var storyboardIdentifier:String? { return \"\(viewControllerId)\" }\n"
-                output += "    class func instantiateFromStoryboard(storyboard: Storyboards) -> \(customClass)! {\n"
-                output += "        return storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(self.storyboardIdentifier!) as? \(customClass)\n"
-                output += "    }\n"
-            }
-            output += "}"
-            result = output
-        }
-        return result
+    private func showCustomImport() -> Bool {
+        return self.customModule != nil && self.customModuleProvider == nil
     }
     
 }
@@ -891,10 +874,48 @@ class Storyboard: XMLObject {
         return []
     }()
 
-    func processStoryboard() {
+    func processStoryboard(storyboardName: String, os: OS) {
+        println()
+        println("    struct \(storyboardName) {")
+        println()
+        println("        static let identifier = \"\(storyboardName)\"")
+        println()
+        println("        static var storyboard:\(os.storyboardType) {")
+        println("            return \(os.storyboardType)(name: self.identifier, bundle: nil)\(os.storyboardTypeUnwrap)")
+        println("        }")
+        if let initialViewControllerClass = self.initialViewControllerClass {
+            println()
+            println("        static func instantiateInitial\(os.storyboardControllerSignatureType)() -> \(os.storyboardControllerReturnType)? {")
+            println("            return self.storyboard.instantiateInitial\(os.storyboardControllerSignatureType)() \(os.storyboardControllerInitialReturnTypeCast(initialViewControllerClass))")
+            println("        }")
+        }
+        println()
+        println("        static func instantiate\(os.storyboardControllerSignatureType)WithIdentifier(identifier: String) -> \(os.storyboardControllerReturnType) {")
+        println("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(identifier)\(os.storyboardControllerReturnTypeCast)")
+        println("        }")
+        for scene in self.scenes {
+            if let viewController = scene.viewController, customClass = viewController.customClass, storyboardIdentifier = viewController.storyboardIdentifier {
+                println()
+                println("        static func \(storyboardIdentifier)() -> \(customClass)! {")
+                println("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(\"\(storyboardIdentifier)\") as? \(customClass)\n")
+                println("        }")
+            }
+        }
+        println("    }")
+    }
+    
+    func processViewControllers() {
         for scene in self.scenes {
             if let viewController = scene.viewController {
                 if let customClass = viewController.customClass {
+                    println()
+                    println("//MARK: - \(customClass)")
+                    
+                    if viewController.showCustomImport() {
+                        println("import \(viewController.customModule)")
+                        println()
+                    }
+
                     if let segues = scene.segues?.filter({ return $0.identifier != nil })
                         where segues.count > 0 {
                             println("extension \(os.storyboardSegueType) {")
@@ -905,16 +926,9 @@ class Storyboard: XMLObject {
                             println("        return nil")
                             println("    }")
                             println("}")
+                            println()
                     }
                     
-                    
-                    println()
-                    println("//MARK: - \(customClass)")
-                    if let identifierExtenstionString = viewController.storyboardIdentifierExtension(os) {
-                        println()
-                        println(identifierExtenstionString)
-                        println()
-                    }
                     if let segues = scene.segues?.filter({ return $0.identifier != nil })
                         where segues.count > 0 {
                             println("extension \(customClass) { ")
@@ -961,7 +975,7 @@ class Storyboard: XMLObject {
                             println("        var description: String { return self.rawValue }")
                             println("    }")
                             println()
-                            println("}\n")
+                            println("}")
                     }
                 }
             }
@@ -1013,6 +1027,7 @@ func findStoryboards(rootPath: String, suffix: String) -> [String]? {
 }
 
 func processStoryboards(storyboards: [StoryboardFile], os: OS) {
+    
     println("//")
     println("// Autogenerated by Natalie - Storyboard Generator Script.")
     println("// http://blog.krzyzanowskim.com")
@@ -1021,34 +1036,10 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     println("import \(os.framework)")
     println()
     println("//MARK: - Storyboards")
-    println("enum Storyboards: String {")
-    for storyboard in storyboards {
-        let storyboardName = storyboard.storyboardName
-        println("    case \(storyboardName) = \"\(storyboardName)\"")
-    }
-    println()
-    println("    private var instance:\(os.storyboardType) {")
-    println("        return \(os.storyboardType)(name: self.rawValue, bundle: nil)\(os.storyboardTypeUnwrap)")
-    println("    }")
-    println()
-    println("    func instantiateInitial\(os.storyboardControllerSignatureType)() -> \(os.storyboardControllerReturnType)? {")
-    println("        switch (self) {")
+    println("struct Storyboards {")
     for file in storyboards {
-        if let initialViewControllerClass = file.storyboard?.initialViewControllerClass {
-            let storyboardName = file.storyboardName
-            println("        case \(storyboardName):")
-            println("            return self.instance.instantiateInitial\(os.storyboardControllerSignatureType)() \(os.storyboardControllerInitialReturnTypeCast(initialViewControllerClass))")
-
-        }
+        file.storyboard?.processStoryboard(file.storyboardName, os: os)
     }
-    println("        default:")
-    println("            return self.instance.instantiateInitial\(os.storyboardControllerSignatureType)() \(os.storyboardControllerInitialReturnTypeCast)")
-    println("        }")
-    println("    }")
-    println()
-    println("    func instantiate\(os.storyboardControllerSignatureType)WithIdentifier(identifier: String) -> \(os.storyboardControllerReturnType) {")
-    println("        return self.instance.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(identifier)\(os.storyboardControllerReturnTypeCast)")
-    println("    }")
     println("}")
     println()
     
@@ -1091,7 +1082,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
 	println()
     
     for file in storyboards {
-        file.storyboard?.processStoryboard()
+        file.storyboard?.processViewControllers()
     }
 
 }

--- a/natalie.swift
+++ b/natalie.swift
@@ -885,7 +885,7 @@ class Storyboard: XMLObject {
         println("        }")
         if let initialViewControllerClass = self.initialViewControllerClass {
             println()
-            println("        static func instantiateInitial\(os.storyboardControllerSignatureType)() -> \(os.storyboardControllerReturnType)? {")
+            println("        static func instantiateInitial\(os.storyboardControllerSignatureType)() -> \(initialViewControllerClass)! {")
             println("            return self.storyboard.instantiateInitial\(os.storyboardControllerSignatureType)() \(os.storyboardControllerInitialReturnTypeCast(initialViewControllerClass))")
             println("        }")
         }
@@ -897,7 +897,7 @@ class Storyboard: XMLObject {
             if let viewController = scene.viewController, customClass = viewController.customClass, storyboardIdentifier = viewController.storyboardIdentifier {
                 println()
                 println("        static func \(storyboardIdentifier)() -> \(customClass)! {")
-                println("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(\"\(storyboardIdentifier)\") as? \(customClass)\n")
+                println("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(\"\(storyboardIdentifier)\") as! \(customClass)\n")
                 println("        }")
             }
         }


### PR DESCRIPTION
Hi,

I modified quite a few things, the main reason was to be able to use the same ViewController class multiple times in different storyboards each with a different Storyboard ID.
This was impossible before because you would end up adding an extension twice to the same class.

Now because the storyboards are structs, it means that I was able to specialise instantiateInitialViewController method so that the return type is the same as the type of the ViewController.

To instantiate a Viewcontroller with id "ListVC" in storyboard Main, you do:

``` swift
let vc = Storyboards.Main.ListVC()
```

If you have any questions or remarks, my ears are open.

![Open ears](http://media.giphy.com/media/2lzhUOZsRY86Y/giphy.gif)
