### PR TITLE
use nil for sender in performSegue as a default value

### DIFF
--- a/NatalieExample/NatalieExample/MainViewController.swift
+++ b/NatalieExample/NatalieExample/MainViewController.swift
@@ -51,7 +51,7 @@ class MainViewController: UIViewController {
     //MARK: Actions
     
     @IBAction func screen1ButtonPressed(button:UIButton) {
-        self.performSegue(MainViewController.Segue.ScreenOneSegue, sender: nil)
+        self.performSegue(MainViewController.Segue.ScreenOneSegue)
     }
 
     @IBAction func screen22ButtonPressed(button:UIButton) {

--- a/NatalieExample/NatalieExample/Storyboards.swift
+++ b/NatalieExample/NatalieExample/Storyboards.swift
@@ -98,8 +98,12 @@ extension UITableViewCell: ReusableProtocol {
 
 //MARK: - UIViewController extension
 extension UIViewController {
-    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject? = nil) {
+    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject?) {
        performSegueWithIdentifier(segue.identifier, sender: sender)
+    }
+
+    func performSegue<T: SegueProtocol>(segue: T) {
+       performSegue(segue, sender: nil)
     }
 }
 

--- a/NatalieExample/NatalieExample/Storyboards.swift
+++ b/NatalieExample/NatalieExample/Storyboards.swift
@@ -98,7 +98,7 @@ extension UITableViewCell: ReusableProtocol {
 
 //MARK: - UIViewController extension
 extension UIViewController {
-    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject?) {
+    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject? = nil) {
        performSegueWithIdentifier(segue.identifier, sender: sender)
     }
 }

--- a/natalie.swift
+++ b/natalie.swift
@@ -1198,13 +1198,17 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     for controllerType in os.storyboardControllerTypes {
         println("//MARK: - \(controllerType) extension")
         println("extension \(controllerType) {")
-        println("    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject? = nil) {")
+        println("    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject?) {")
         println("       performSegueWithIdentifier(segue.identifier\(os.storyboardSegueUnwrap), sender: sender)")
+        println("    }")
+        println()
+        println("    func performSegue<T: SegueProtocol>(segue: T) {")
+        println("       performSegue(segue, sender: nil)")
         println("    }")
         println("}")
         println()
     }
-    
+  
     if os == OS.iOS {
         println("//MARK: - UICollectionViewController")
         println()

--- a/natalie.swift
+++ b/natalie.swift
@@ -1198,7 +1198,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     for controllerType in os.storyboardControllerTypes {
         println("//MARK: - \(controllerType) extension")
         println("extension \(controllerType) {")
-        println("    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject?) {")
+        println("    func performSegue<T: SegueProtocol>(segue: T, sender: AnyObject? = nil) {")
         println("       performSegueWithIdentifier(segue.identifier\(os.storyboardSegueUnwrap), sender: sender)")
         println("    }")
         println("}")


### PR DESCRIPTION
because `sender` is optional, I think it's nice to be able to skip it when you call 
`performSegue(MainViewController.Segue.ScreenOneSegue)`
