### PR TITLE
Remove unused default case

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -55,31 +55,31 @@ let rootElementName = "SWXMLHash_Root_Element"
 public class SWXMLHash {
     /**
     Method to parse XML passed in as a string.
-    
+
     - parameter xml: The XML to be parsed
-    
+
     - returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func parse(xml: String) -> XMLIndexer {
         return parse((xml as NSString).dataUsingEncoding(NSUTF8StringEncoding)!)
     }
-    
+
     /**
     Method to parse XML passed in as an NSData instance.
-    
+
     - parameter xml: The XML to be parsed
-    
+
     - returns: An XMLIndexer instance that is used to look up elements in the XML
     */
     class public func parse(data: NSData) -> XMLIndexer {
         let parser = XMLParser()
         return parser.parse(data)
     }
-    
+
     class public func lazy(xml: String) -> XMLIndexer {
         return lazy((xml as NSString).dataUsingEncoding(NSUTF8StringEncoding)!)
     }
-    
+
     class public func lazy(data: NSData) -> XMLIndexer {
         let parser = LazyXMLParser()
         return parser.parse(data)
@@ -106,65 +106,65 @@ class LazyXMLParser : NSObject, NSXMLParserDelegate {
     override init() {
         super.init()
     }
-    
+
     var root = XMLElement(name: rootElementName)
     var parentStack = Stack<XMLElement>()
     var elementStack = Stack<String>()
-    
+
     var data: NSData?
     var ops: [IndexOp] = []
-    
+
     func parse(data: NSData) -> XMLIndexer {
         self.data = data
         return XMLIndexer(self)
     }
-    
+
     func startParsing(ops: [IndexOp]) {
         // clear any prior runs of parse... expected that this won't be necessary, but you never know
         parentStack.removeAll()
         root = XMLElement(name: rootElementName)
         parentStack.push(root)
-        
+
         self.ops = ops
         let parser = NSXMLParser(data: data!)
         parser.delegate = self
         parser.parse()
     }
-    
+
     func parser(parser: NSXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String]) {
-        
+
         elementStack.push(elementName)
-        
+
         if !onMatch() {
             return
         }
         let currentNode = parentStack.top().addElement(elementName, withAttributes: attributeDict)
         parentStack.push(currentNode)
     }
-    
+
     func parser(parser: NSXMLParser, foundCharacters string: String) {
         if !onMatch() {
             return
         }
-        
+
         let current = parentStack.top()
         if current.text == nil {
             current.text = ""
         }
-        
+
         parentStack.top().text! += string
     }
-    
+
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         let match = onMatch()
-        
+
         elementStack.pop()
-        
+
         if match {
             parentStack.pop()
         }
     }
-    
+
     func onMatch() -> Bool {
         // we typically want to compare against the elementStack to see if it matches ops, *but*
         // if we're on the first element, we'll instead compare the other direction.
@@ -182,38 +182,38 @@ class XMLParser : NSObject, NSXMLParserDelegate {
     override init() {
         super.init()
     }
-    
+
     var root = XMLElement(name: rootElementName)
     var parentStack = Stack<XMLElement>()
-    
+
     func parse(data: NSData) -> XMLIndexer {
         // clear any prior runs of parse... expected that this won't be necessary, but you never know
         parentStack.removeAll()
-        
+
         parentStack.push(root)
-        
+
         let parser = NSXMLParser(data: data)
         parser.delegate = self
         parser.parse()
-        
+
         return XMLIndexer(root)
     }
-    
+
     func parser(parser: NSXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String]) {
-        
+
         let currentNode = parentStack.top().addElement(elementName, withAttributes: attributeDict)
         parentStack.push(currentNode)
     }
-    
+
     func parser(parser: NSXMLParser, foundCharacters string: String) {
         let current = parentStack.top()
         if current.text == nil {
             current.text = ""
         }
-        
+
         parentStack.top().text! += string
     }
-    
+
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         parentStack.pop()
     }
@@ -222,30 +222,30 @@ class XMLParser : NSObject, NSXMLParserDelegate {
 public class IndexOp {
     var index: Int
     let key: String
-    
+
     init(_ key: String) {
         self.key = key
         self.index = -1
     }
-    
+
     func toString() -> String {
         if index >= 0 {
             return key + " " + index.description
         }
-        
+
         return key
     }
 }
 
 public class IndexOps {
     var ops: [IndexOp] = []
-    
+
     let parser: LazyXMLParser
-    
+
     init(parser: LazyXMLParser) {
         self.parser = parser
     }
-    
+
     func findElements() -> XMLIndexer {
         parser.startParsing(ops)
         let indexer = XMLIndexer(parser.root)
@@ -259,7 +259,7 @@ public class IndexOps {
         ops.removeAll(keepCapacity: false)
         return childIndex
     }
-    
+
     func stringify() -> String {
         var s = ""
         for op in ops {
@@ -275,7 +275,7 @@ public enum XMLIndexer : SequenceType {
     case List([XMLElement])
     case Stream(IndexOps)
     case Error(NSError)
-    
+
     /// The underlying XMLElement at the currently indexed level of XML.
     public var element: XMLElement? {
         get {
@@ -290,7 +290,7 @@ public enum XMLIndexer : SequenceType {
             }
         }
     }
-    
+
     /// All elements at the currently indexed level
     public var all: [XMLIndexer] {
         get {
@@ -311,7 +311,7 @@ public enum XMLIndexer : SequenceType {
             }
         }
     }
-    
+
     /// All child elements from the currently indexed level
     public var children: [XMLIndexer] {
         get {
@@ -324,13 +324,13 @@ public enum XMLIndexer : SequenceType {
             return list
         }
     }
-    
+
     /**
     Allows for element lookup by matching attribute values.
-    
+
     - parameter attr: should the name of the attribute to match on
     - parameter _: should be the value of the attribute to match on
-    
+
     - returns: instance of XMLIndexer
     */
     public func withAttr(attr: String, _ value: String) -> XMLIndexer {
@@ -358,12 +358,12 @@ public enum XMLIndexer : SequenceType {
             return .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: attrUserInfo))
         }
     }
-    
+
     /**
     Initializes the XMLIndexer
-    
+
     - parameter _: should be an instance of XMLElement, but supports other values for error handling
-    
+
     - returns: instance of XMLIndexer
     */
     public init(_ rawObject: AnyObject) {
@@ -376,12 +376,12 @@ public enum XMLIndexer : SequenceType {
             self = .Error(NSError(domain: "SWXMLDomain", code: 1000, userInfo: nil))
         }
     }
-    
+
     /**
     Find an XML element at the current level by element name
-    
+
     - parameter key: The element name to index by
-    
+
     - returns: instance of XMLIndexer to match the element (or elements) found by key
     */
     public subscript(key: String) -> XMLIndexer {
@@ -408,12 +408,12 @@ public enum XMLIndexer : SequenceType {
             }
         }
     }
-    
+
     /**
     Find an XML element by index within a list of XML Elements at the current level
-    
+
     - parameter index: The 0-based index to index by
-    
+
     - returns: instance of XMLIndexer to match the element (or elements) found by key
     */
     public subscript(index: Int) -> XMLIndexer {
@@ -440,9 +440,9 @@ public enum XMLIndexer : SequenceType {
             }
         }
     }
-    
+
     typealias GeneratorType = XMLIndexer
-    
+
     public func generate() -> IndexingGenerator<[XMLIndexer]> {
         return all.generate()
     }
@@ -473,7 +473,7 @@ extension XMLIndexer: CustomStringConvertible {
                 if elem.name == rootElementName {
                     return "\n".join(elem.children.map { $0.description })
                 }
-                
+
                 return elem.description
             default:
                 return ""
@@ -490,43 +490,43 @@ public class XMLElement {
     public var text: String?
     /// The attributes of the element
     public var attributes = [String:String]()
-    
+
     var children = [XMLElement]()
     var count: Int = 0
     var index: Int
-    
+
     /**
     Initialize an XMLElement instance
-    
+
     - parameter name: The name of the element to be initialized
-    
+
     - returns: a new instance of XMLElement
     */
     init(name: String, index: Int = 0) {
         self.name = name
         self.index = index
     }
-    
+
     /**
     Adds a new XMLElement underneath this instance of XMLElement
-    
+
     - parameter name: The name of the new element to be added
     - parameter withAttributes: The attributes dictionary for the element being added
-    
+
     - returns: The XMLElement that has now been added
     */
     func addElement(name: String, withAttributes attributes: NSDictionary) -> XMLElement {
         let element = XMLElement(name: name, index: count)
         count++
-        
+
         children.append(element)
-        
+
         for (keyAny,valueAny) in attributes {
             let key = keyAny as! String
             let value = valueAny as! String
             element.attributes[key] = value
         }
-        
+
         return element
     }
 }
@@ -540,12 +540,12 @@ extension XMLElement: CustomStringConvertible {
                     attributesStringList.append("\(key)=\"\(val)\"")
                 }
             }
-            
+
             var attributesString = " ".join(attributesStringList)
             if (!attributesString.isEmpty) {
                 attributesString = " " + attributesString
             }
-            
+
             if children.count > 0 {
                 var xmlReturn = [String]()
                 xmlReturn.append("<\(name)\(attributesString)>")
@@ -555,7 +555,7 @@ extension XMLElement: CustomStringConvertible {
                 xmlReturn.append("</\(name)>")
                 return "\n".join(xmlReturn)
             }
-            
+
             if text != nil {
                 return "<\(name)\(attributesString)>\(text!)</\(name)>"
             }
@@ -572,13 +572,13 @@ extension XMLElement: CustomStringConvertible {
 enum OS: String, CustomStringConvertible {
     case iOS = "iOS"
     case OSX = "OSX"
-    
+
     static let allValues = [iOS, OSX]
-    
+
     enum Runtime: String {
         case iOSCocoaTouch = "iOS.CocoaTouch"
         case MacOSXCocoa = "MacOSX.Cocoa"
-        
+
         init(os: OS) {
             switch os {
             case iOS:
@@ -587,13 +587,13 @@ enum OS: String, CustomStringConvertible {
                 self = .MacOSXCocoa
             }
         }
-        
+
     }
-    
+
     enum Framework: String {
         case UIKit = "UIKit"
         case Cocoa = "Cocoa"
-        
+
         init(os: OS) {
             switch os {
             case iOS:
@@ -603,7 +603,7 @@ enum OS: String, CustomStringConvertible {
             }
         }
     }
-    
+
     init(targetRuntime: String) {
         switch (targetRuntime) {
         case Runtime.iOSCocoaTouch.rawValue:
@@ -616,19 +616,19 @@ enum OS: String, CustomStringConvertible {
             fatalError("Unsupported")
         }
     }
-    
+
     var description: String {
         return self.rawValue
     }
-    
+
     var framework: String {
         return Framework(os: self).rawValue
     }
-    
+
     var targetRuntime: String {
         return Runtime(os: self).rawValue
     }
-    
+
     var storyboardType: String {
         switch self {
         case iOS:
@@ -637,7 +637,7 @@ enum OS: String, CustomStringConvertible {
             return "NSStoryboard"
         }
     }
-    
+
     var storyboardSegueType: String {
         switch self {
         case iOS:
@@ -646,7 +646,7 @@ enum OS: String, CustomStringConvertible {
             return "NSStoryboardSegue"
         }
     }
-    
+
     var storyboardTypeUnwrap: String {
         switch self {
         case iOS:
@@ -655,7 +655,7 @@ enum OS: String, CustomStringConvertible {
             return "!"
         }
     }
-    
+
     var storyboardControllerTypes: [String] {
         switch self {
         case iOS:
@@ -664,7 +664,7 @@ enum OS: String, CustomStringConvertible {
             return ["NSViewController", "NSWindowController"]
         }
     }
-    
+
     var storyboardControllerSignatureType: String {
         switch self {
         case iOS:
@@ -673,7 +673,7 @@ enum OS: String, CustomStringConvertible {
             return "Controller" // NSViewController or NSWindowController
         }
     }
-    
+
     var viewType: String {
         switch self {
         case iOS:
@@ -682,7 +682,7 @@ enum OS: String, CustomStringConvertible {
             return "NSView"
         }
     }
-    
+
     var resuableViews: [String]? {
         switch self {
         case iOS:
@@ -691,7 +691,7 @@ enum OS: String, CustomStringConvertible {
             return nil
         }
     }
-    
+
     var storyboardControllerReturnType: String {
         switch self {
         case iOS:
@@ -700,7 +700,7 @@ enum OS: String, CustomStringConvertible {
             return "AnyObject" // NSViewController or NSWindowController
         }
     }
-    
+
     var storyboardControllerInitialReturnTypeCast: String {
         switch self {
         case iOS:
@@ -719,7 +719,7 @@ enum OS: String, CustomStringConvertible {
             return " as! \(self.storyboardControllerReturnType)"
         }
     }
-    
+
     func storyboardControllerInitialReturnTypeCast(initialClass: String) -> String {
         switch self {
         case iOS:
@@ -728,7 +728,7 @@ enum OS: String, CustomStringConvertible {
             return ""
         }
     }
-    
+
     func controllerTypeForElementName(name: String) -> String? {
         switch self {
         case iOS:
@@ -759,27 +759,27 @@ enum OS: String, CustomStringConvertible {
             }
         }
     }
-    
+
 }
 
 class XMLObject {
-    
+
     var xml: XMLIndexer
-    
+
     lazy var name: String? = self.xml.element?.name
-    
+
     init(xml: XMLIndexer) {
         self.xml = xml
     }
-    
+
     func searchAll(attributeKey: String, attributeValue: String? = nil) -> [XMLIndexer]? {
         return searchAll(self.xml, attributeKey: attributeKey, attributeValue: attributeValue)
     }
-    
+
     func searchAll(root: XMLIndexer, attributeKey: String, attributeValue: String? = nil) -> [XMLIndexer]? {
         var result = Array<XMLIndexer>()
         for child in root.children {
-            
+
             for childAtLevel in child.all {
                 if let attributeValue = attributeValue {
                     if let element = childAtLevel.element where element.attributes[attributeKey] == attributeValue {
@@ -788,7 +788,7 @@ class XMLObject {
                 } else if let element = childAtLevel.element where element.attributes[attributeKey] != nil {
                     result += [childAtLevel]
                 }
-                
+
                 if let found = searchAll(childAtLevel, attributeKey: attributeKey, attributeValue: attributeValue) {
                     result += found
                 }
@@ -796,15 +796,15 @@ class XMLObject {
         }
         return result.count > 0 ? result : nil
     }
-    
+
     func searchNamed(name: String) -> [XMLIndexer]? {
         return self.searchNamed(self.xml, name: name)
     }
-    
+
     func searchNamed(root: XMLIndexer, name: String) -> [XMLIndexer]? {
         var result = Array<XMLIndexer>()
         for child in root.children {
-            
+
             for childAtLevel in child.all {
                 if let elementName = childAtLevel.element?.name where elementName == name {
                     result += [child]
@@ -816,36 +816,36 @@ class XMLObject {
         }
         return result.count > 0 ? result : nil
     }
-    
+
     func searchById(id: String) -> XMLIndexer? {
         return searchAll("id", attributeValue: id)?.first
     }
 }
 
 class Scene: XMLObject {
-    
+
     lazy var viewController: ViewController? = {
         if let vcs = self.searchAll("sceneMemberID", attributeValue: "viewController"), vc = vcs.first {
             return ViewController(xml: vc)
         }
         return nil
         }()
-    
+
     lazy var segues: [Segue]? = {
         return self.searchNamed("segue")?.map { Segue(xml: $0) }
         }()
-    
+
     lazy var customModule: String? = self.viewController?.customModule
     lazy var customModuleProvider: String? = self.viewController?.customModuleProvider
 }
 
 class ViewController: XMLObject {
-    
+
     lazy var customClass: String? = self.xml.element?.attributes["customClass"]
     lazy var customModuleProvider: String? = self.xml.element?.attributes["customModuleProvider"]
     lazy var storyboardIdentifier: String? = self.xml.element?.attributes["storyboardIdentifier"]
     lazy var customModule: String? = self.xml.element?.attributes["customModule"]
-    
+
     lazy var reusables: [Reusable]? = {
         if let reusables = self.searchAll(self.xml, attributeKey: "reuseIdentifier"){
             return reusables.map { Reusable(xml: $0) }
@@ -855,21 +855,21 @@ class ViewController: XMLObject {
 }
 
 class Segue: XMLObject {
-    
+
     lazy var identifier: String? = self.xml.element?.attributes["identifier"]
     lazy var kind: String? = self.xml.element?.attributes["kind"]
     lazy var destination: String? = self.xml.element?.attributes["destination"]
 }
 
 class Reusable: XMLObject {
-    
+
     lazy var reuseIdentifier: String? = self.xml.element?.attributes["reuseIdentifier"]
     lazy var customClass: String? = self.xml.element?.attributes["customClass"]
     lazy var kind: String? = self.xml.element?.name
 }
 
 class Storyboard: XMLObject {
-    
+
     lazy var os:OS = self.initOS() ?? OS.iOS
     private func initOS() -> OS? {
         if let targetRuntime = self.xml["document"].element?.attributes["targetRuntime"] {
@@ -877,7 +877,7 @@ class Storyboard: XMLObject {
         }
         return nil
     }
-    
+
     lazy var initialViewControllerClass: String? = self.initInitialViewControllerClass()
     private func initInitialViewControllerClass() -> String? {
         if let initialViewControllerId = xml["document"].element?.attributes["initialViewController"],
@@ -887,25 +887,25 @@ class Storyboard: XMLObject {
             if let customClassName = vc.customClass {
                 return customClassName
             }
-            
+
             if let name = vc.name, controllerType = os.controllerTypeForElementName(name) {
                 return controllerType
             }
         }
         return nil
     }
-    
+
     lazy var version: String? = self.xml["document"].element?.attributes["version"]
-    
+
     lazy var scenes: [Scene] = {
         if let scenes = self.searchAll(self.xml, attributeKey: "sceneID"){
             return scenes.map { Scene(xml: $0) }
         }
         return []
         }()
-    
+
     lazy var customModules: [String] = self.scenes.filter{ $0.customModule != nil && $0.customModuleProvider == nil  }.map{ $0.customModule! }
-    
+
     func processStoryboard(storyboardName: String, os: OS) {
         print("")
         print("    struct \(storyboardName) {")
@@ -935,14 +935,14 @@ class Storyboard: XMLObject {
         }
         print("    }")
     }
-    
+
     func processViewControllers() {
         for scene in self.scenes {
             if let viewController = scene.viewController {
                 if let customClass = viewController.customClass {
                     print("")
                     print("//MARK: - \(customClass)")
-                    
+
                     if let segues = scene.segues?.filter({ return $0.identifier != nil })
                         where segues.count > 0 {
                             print("extension \(os.storyboardSegueType) {")
@@ -955,7 +955,7 @@ class Storyboard: XMLObject {
                             print("}")
                             print("")
                     }
-                    
+
                     if let segues = scene.segues?.filter({ return $0.identifier != nil })
                         where segues.count > 0 {
                             print("extension \(customClass) { ")
@@ -1014,10 +1014,10 @@ class Storyboard: XMLObject {
                             print("")
                             print("}")
                     }
-                    
+
                     if let reusables = viewController.reusables?.filter({ return $0.reuseIdentifier != nil })
                         where reusables.count > 0 {
-                            
+
                             print("extension \(customClass) { ")
                             print("")
                             print("    enum Reusable: String, CustomStringConvertible, ReusableViewProtocol {")
@@ -1049,15 +1049,18 @@ class Storyboard: XMLObject {
                             print("")
                             print("        var viewType: \(self.os.viewType).Type? {")
                             print("            switch (self) {")
-                            for reusable in reusables {
-                                if let identifier = reusable.reuseIdentifier, customClass = reusable.customClass
-                                {
-                                    print("            case \(identifier):")
-                                    print("                return \(customClass).self")
+                            if reusables.isEmpty {
+                                print("            default:")
+                                print("                return nil")
+                            } else {
+                                for reusable in reusables {
+                                    if let identifier = reusable.reuseIdentifier, customClass = reusable.customClass
+                                    {
+                                        print("            case \(identifier):")
+                                        print("                return \(customClass).self")
+                                    }
                                 }
                             }
-                            print("            default:")
-                            print("                return nil")
                             print("            }")
                             print("        }")
                             print("")
@@ -1074,14 +1077,14 @@ class Storyboard: XMLObject {
 }
 
 class StoryboardFile {
-    
+
     let filePath: String
     init(filePath: String){
         self.filePath = filePath
     }
-    
+
     lazy var storyboardName: String = self.filePath.lastPathComponent.stringByDeletingPathExtension
-    
+
     lazy var data: NSData? = NSData(contentsOfFile: self.filePath)
     lazy var xml: XMLIndexer? = {
         if let d = self.data {
@@ -1089,7 +1092,7 @@ class StoryboardFile {
         }
         return nil
         }()
-    
+
     lazy var storyboard: Storyboard? = {
         if let xml = self.xml {
             return Storyboard(xml:xml)
@@ -1115,7 +1118,7 @@ func findStoryboards(rootPath: String, suffix: String) -> [String]? {
 }
 
 func processStoryboards(storyboards: [StoryboardFile], os: OS) {
-    
+
     print("//")
     print("// Autogenerated by Natalie - Storyboard Generator Script.")
     print("// http://blog.krzyzanowskim.com")
@@ -1127,7 +1130,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
         print("import \(module)")
     }
     print("")
-    
+
     print("//MARK: - Storyboards")
     print("struct Storyboards {")
     for file in storyboards {
@@ -1135,7 +1138,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     }
     print("}")
     print("")
-    
+
     print("//MARK: - ReusableKind")
     print("enum ReusableKind: String, CustomStringConvertible {")
     print("    case TableViewCell = \"tableViewCell\"")
@@ -1144,7 +1147,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     print("    var description: String { return self.rawValue }")
     print("}")
     print("")
-    
+
     print("//MARK: - SegueKind")
     print("enum SegueKind: String, CustomStringConvertible {    ")
     print("    case Relationship = \"relationship\" ")
@@ -1156,7 +1159,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     print("    var description: String { return self.rawValue } ")
     print("}")
     print("")
-    
+
     print("//MARK: - SegueProtocol")
     print("public protocol IdentifiableProtocol: Equatable {")
     print("    var identifier: String? { get }")
@@ -1165,7 +1168,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     print("public protocol SegueProtocol: IdentifiableProtocol {")
     print("}")
     print("")
-    
+
     print("public func ==<T: SegueProtocol, U: SegueProtocol>(lhs: T, rhs: U) -> Bool {")
     print("   return lhs.identifier == rhs.identifier")
     print("}")
@@ -1182,23 +1185,23 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
     print("   return lhs.identifier == rhs")
     print("}")
     print("")
-    
+
     print("//MARK: - ReusableViewProtocol")
     print("public protocol ReusableViewProtocol: IdentifiableProtocol {")
     print("    var viewType: \(os.viewType).Type? {get}")
     print("}")
     print("")
-    
+
     print("public func ==<T: ReusableViewProtocol, U: ReusableViewProtocol>(lhs: T, rhs: U) -> Bool {")
     print("   return lhs.identifier == rhs.identifier")
     print("}")
     print("")
-    
+
     print("//MARK: - Protocol Implementation")
     print("extension \(os.storyboardSegueType): SegueProtocol {")
     print("}")
     print("")
-    
+
     if let reusableViews = os.resuableViews {
         for reusableView in reusableViews {
             print("extension \(reusableView): ReusableViewProtocol {")
@@ -1208,7 +1211,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
             print("")
         }
     }
-    
+
     for controllerType in os.storyboardControllerTypes {
         print("//MARK: - \(controllerType) extension")
         print("extension \(controllerType) {")
@@ -1224,7 +1227,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
         print("}")
         print("")
     }
-    
+
     if os == OS.iOS {
         print("//MARK: - UICollectionView")
         print("")
@@ -1256,7 +1259,7 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
         print("        }")
         print("    }")
         print("}")
-        
+
         print("//MARK: - UITableView")
         print("")
         print("extension UITableView {")
@@ -1289,11 +1292,11 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
         print("}")
         print("")
     }
-    
+
     for file in storyboards {
         file.storyboard?.processViewControllers()
     }
-    
+
 }
 
 //MARK: MAIN()
@@ -1316,13 +1319,13 @@ let storyboardFiles: [StoryboardFile] = storyboards.map { StoryboardFile(filePat
 for os in OS.allValues {
     var storyboardsForOS = storyboardFiles.filter { $0.storyboard?.os == os }
     if !storyboardsForOS.isEmpty {
-        
+
         if storyboardsForOS.count != storyboardFiles.count {
             print("#if os(\(os.rawValue))")
         }
-        
+
         processStoryboards(storyboardsForOS, os: os)
-        
+
         if storyboardsForOS.count != storyboardFiles.count {
             print("#endif")
         }

--- a/natalie.swift
+++ b/natalie.swift
@@ -1049,17 +1049,18 @@ class Storyboard: XMLObject {
                             print("")
                             print("        var viewType: \(self.os.viewType).Type? {")
                             print("            switch (self) {")
-                            if reusables.isEmpty {
+                            needDefault = false
+                            for reusable in reusables {
+                                if let identifier = reusable.reuseIdentifier, customClass = reusable.customClass {
+                                    print("            case \(identifier):")
+                                    print("                return \(customClass).self")
+                                } else {
+                                    needDefault = true
+                                }
+                            }
+                            if needDefault {
                                 print("            default:")
                                 print("                return nil")
-                            } else {
-                                for reusable in reusables {
-                                    if let identifier = reusable.reuseIdentifier, customClass = reusable.customClass
-                                    {
-                                        print("            case \(identifier):")
-                                        print("                return \(customClass).self")
-                                    }
-                                }
                             }
                             print("            }")
                             print("        }")


### PR DESCRIPTION
If there are any other cases—i.e., all cases are accounted for—the Swift compiler will complain that the default case is never executed.
