### PR TITLE
Add public specifier to variables in Objective-C classes

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -979,7 +979,7 @@ class Storyboard: XMLObject {
 
                     if let storyboardIdentifier = viewController.storyboardIdentifier {
                         print("extension \(customClass): IdentifiableProtocol { ")
-                        print("    var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
+                        print("    public var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
                         print("    static var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
                         print("}")
                         print("")

--- a/natalie.swift
+++ b/natalie.swift
@@ -979,7 +979,11 @@ class Storyboard: XMLObject {
 
                     if let storyboardIdentifier = viewController.storyboardIdentifier {
                         print("extension \(customClass): IdentifiableProtocol { ")
-                        print("    public var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
+                        if viewController.customModule != nil {
+                            print("    var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
+                        } else {
+                            print("    public var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
+                        }
                         print("    static var storyboardIdentifier: String? { return \"\(storyboardIdentifier)\" }")
                         print("}")
                         print("")


### PR DESCRIPTION
Objective-C view controllers do not work with the current version of Natalie. This error occurs when compiling. 

`error: property 'storyboardIdentifier' must be declared public because it matches a requirement in public protocol 'IdentifiableProtocol'`

To fix this, I've added a public specifier to variables in classes that are Objective-C. Objective-C classes do not have a defined module in the Storyboard XML.
