### PR TITLE
Remove warning when scene type is default type

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -951,9 +951,10 @@ class Storyboard: XMLObject {
         for scene in self.scenes {
             if let viewController = scene.viewController, storyboardIdentifier = viewController.storyboardIdentifier {
                 let controllerClass = (viewController.customClass ?? os.controllerTypeForElementName(viewController.name)!)
+                let cast = (controllerClass == os.storyboardControllerReturnType ? "" : " as! \(controllerClass)")
                 print("")
                 print("        static func instantiate\(SwiftRepresentationForString(storyboardIdentifier, capitalizeFirstLetter: true))() -> \(controllerClass) {")
-                print("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(\"\(storyboardIdentifier)\") as! \(controllerClass)")
+                print("            return self.storyboard.instantiate\(os.storyboardControllerSignatureType)WithIdentifier(\"\(storyboardIdentifier)\")\(cast)")
                 print("        }")
             }
         }


### PR DESCRIPTION
When the user not set any specific type for ViewController on the storyboard it raise a warning.
I proposed to do the save treatment for casting that it already does for returntype.
