### PR TITLE
Fix parenthesis into Storyboard extension

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -1168,9 +1168,9 @@ func processStoryboards(storyboards: [StoryboardFile], os: OS) {
         print("        }")
         print("        return nil")
         print("    }")
-        print("}")
         print("")
     }
+    print("}")
 
     print("")
     print("protocol Storyboard {")


### PR DESCRIPTION
generated code does't compil on OSX only because of two types of controller(window and view), so block is printed two times with and extra parenthesis
