### PR TITLE
Fix OSX storyboardInstantiationInfo

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -690,7 +690,7 @@ enum OS: String, CustomStringConvertible {
         case iOS:
             return [("ViewController", "UIViewController")]
         case OSX:
-            return [("WindowController", "NSWindowController"), ("ViewController", "NSViewController")]
+            return [("Controller", "NSWindowController"), ("Controller", "NSViewController")]
         }
     }
 


### PR DESCRIPTION
like storyboardControllerSignatureType, the method signature for OSX have no View or Window, just Controller
