### PR TITLE
Fix a warning about upcoming Swift 3.0

### DIFF
--- a/natalie.swift
+++ b/natalie.swift
@@ -530,7 +530,7 @@ public class XMLElement {
     */
     func addElement(name: String, withAttributes attributes: NSDictionary) -> XMLElement {
         let element = XMLElement(name: name, index: count)
-        count++
+        count += 1
 
         children.append(element)
 


### PR DESCRIPTION
`++` will not exist in Swift 3.0 😉
