### PR TITLE
Import only one time custom modules using Set

### DIFF
--- a/Sources/natalie/Parser.swift
+++ b/Sources/natalie/Parser.swift
@@ -34,7 +34,7 @@ struct Parser {
 
         output += header.description
         output += "import \(os.framework)\n"
-        for module in storyboards.lazy.flatMap({ $0.storyboard.customModules }) {
+        for module in Set(storyboards.lazy.flatMap { $0.storyboard.customModules }) {
             output += "import \(module)\n"
         }
         output += "\n"

--- a/Sources/natalie/Storyboard.swift
+++ b/Sources/natalie/Storyboard.swift
@@ -41,7 +41,7 @@ class Storyboard: XMLObject {
         return scenes.map { Scene(xml: $0) }
     }()
 
-    lazy var customModules: [String] = self.scenes.filter{ $0.customModule != nil && $0.customModuleProvider == nil  }.map{ $0.customModule! }
+    lazy var customModules: Set<String> = Set(self.scenes.filter{ $0.customModule != nil && $0.customModuleProvider == nil  }.map{ $0.customModule! })
 
     override init(xml: XMLIndexer) {
         self.version = xml["document"].element!.attributes["version"]!


### PR DESCRIPTION
If a framework is used in multiple object we have in result for instance
```swift
import UIKit
import IBAnimatable
import IBAnimatable
import IBAnimatable
import IBAnimatable
import IBAnimatable
```

replace #97