### PR TITLE
Generate a Color class extension with asset colors used in storyboard

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ disabled_rules:
     - redundant_string_enum_value
     - type_name
     - identifier_name
+    - large_tuple
 
 shorthand_operator: warning
 

--- a/Natalie.xcodeproj/project.pbxproj
+++ b/Natalie.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		75E28AB01D577D0500A80623 /* SWXMLHash+TypeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E28AAA1D577D0500A80623 /* SWXMLHash+TypeConversion.swift */; };
 		75E28AB11D577D0500A80623 /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E28AAB1D577D0500A80623 /* SWXMLHash.swift */; };
 		75E28AB31D577EEA00A80623 /* XMLObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E28AB21D577EEA00A80623 /* XMLObject.swift */; };
+		C4F8BEDF1F9C79BD0031195F /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F8BEDE1F9C79BD0031195F /* Color.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -58,6 +59,7 @@
 		75E28AAA1D577D0500A80623 /* SWXMLHash+TypeConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SWXMLHash+TypeConversion.swift"; sourceTree = "<group>"; };
 		75E28AAB1D577D0500A80623 /* SWXMLHash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SWXMLHash.swift; sourceTree = "<group>"; };
 		75E28AB21D577EEA00A80623 /* XMLObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLObject.swift; sourceTree = "<group>"; };
+		C4F8BEDE1F9C79BD0031195F /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 				7501493A1D57825F00B22C87 /* ViewController.swift */,
 				7501493C1D57827800B22C87 /* Segue.swift */,
 				7501493E1D57828D00B22C87 /* Reusable.swift */,
+				C4F8BEDE1F9C79BD0031195F /* Color.swift */,
 			);
 			name = XMLObject;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				750149411D5782AC00B22C87 /* Storyboard.swift in Sources */,
 				48E3E55D1EE6D85E000D4B3F /* Storyboard+Natalie.swift in Sources */,
 				75E28AB11D577D0500A80623 /* SWXMLHash.swift in Sources */,
+				C4F8BEDF1F9C79BD0031195F /* Color.swift in Sources */,
 				75E28AAD1D577D0500A80623 /* main.swift in Sources */,
 				75E28AAC1D577D0500A80623 /* Helpers.swift in Sources */,
 				7501493F1D57828D00B22C87 /* Reusable.swift in Sources */,

--- a/NatalieExample/NatalieExample.xcodeproj/project.pbxproj
+++ b/NatalieExample/NatalieExample.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = NatalieExample/Info.plist;
 				INFOPLIST_OUTPUT_FORMAT = binary;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.krzyzanowskim.NatalieExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -595,6 +596,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = NatalieExample/Info.plist;
 				INFOPLIST_OUTPUT_FORMAT = binary;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.krzyzanowskim.NatalieExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -622,7 +624,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.2;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -642,7 +644,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.2;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -659,7 +661,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = NatalieOSXExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = me.phimage.NatalieOSXExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -681,7 +683,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = NatalieOSXExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = me.phimage.NatalieOSXExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/NatalieExample/NatalieExample/AppDelegate.swift
+++ b/NatalieExample/NatalieExample/AppDelegate.swift
@@ -28,7 +28,7 @@
 
         var window: UIWindow?
 
-        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+        func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
             return true
         }
 

--- a/NatalieExample/NatalieExample/Base.lproj/Main.storyboard
+++ b/NatalieExample/NatalieExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16B2659" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Wjb-mG-J1I">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Wjb-mG-J1I">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +14,7 @@
             <objects>
                 <navigationController id="Wjb-mG-J1I" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="DdY-nu-pxQ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -131,7 +131,7 @@
                                         <rect key="frame" x="0.0" y="22" width="386" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uoc-UT-z8f" id="gHe-xv-pxa">
-                                            <rect key="frame" x="0.0" y="0.0" width="386" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="386" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XBh-Gg-GL2">
@@ -150,7 +150,7 @@
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" red="0.094094179570674896" green="0.50017184019088745" blue="0.8462483286857605" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="Screen2"/>
                         <constraints>
                             <constraint firstItem="B8k-bv-GZ8" firstAttribute="centerX" secondItem="VN3-UK-6XM" secondAttribute="centerX" id="EOB-Yi-Jpk"/>
                             <constraint firstAttribute="trailing" secondItem="9v1-a2-qz6" secondAttribute="trailing" constant="-11" id="LVH-z0-gPg"/>
@@ -173,7 +173,7 @@
                         <viewControllerLayoutGuide type="top" id="9wl-0o-Yho"/>
                         <viewControllerLayoutGuide type="bottom" id="wJo-UH-XZ9"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="61N-h4-3PO">
+                    <view key="view" contentMode="scaleToFill" restorationIdentifier="Screen1View" id="61N-h4-3PO">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -184,7 +184,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="0.98144435882568359" green="0.57155585289001465" blue="0.041917555034160614" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="Screen1"/>
                         <constraints>
                             <constraint firstItem="3qw-K4-qRq" firstAttribute="top" secondItem="9wl-0o-Yho" secondAttribute="bottom" constant="209" id="6FP-sd-Laq"/>
                             <constraint firstItem="3qw-K4-qRq" firstAttribute="centerX" secondItem="61N-h4-3PO" secondAttribute="centerX" id="vtl-cr-SeY"/>
@@ -225,7 +225,7 @@
                                         <rect key="frame" x="0.0" y="22" width="386" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZTg-Gh-SgL" id="8Jw-US-bn1">
-                                            <rect key="frame" x="0.0" y="0.0" width="386" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="386" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XIl-EG-Zcg">
@@ -260,11 +260,14 @@
             <point key="canvasLocation" x="804" y="1394"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
+    <resources>
+        <namedColor name="Screen1">
+            <color red="0.98100000619888306" green="0.57200002670288086" blue="0.041999999433755875" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Screen2">
+            <color red="0.093999996781349182" green="0.5" blue="0.84600001573562622" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="0VR-ft-sgf"/>
     </inferredMetricsTieBreakers>

--- a/NatalieExample/NatalieExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/NatalieExample/NatalieExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieExample/Images.xcassets/Contents.json
+++ b/NatalieExample/NatalieExample/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/NatalieExample/NatalieExample/Images.xcassets/Screen1.colorset/Contents.json
+++ b/NatalieExample/NatalieExample/Images.xcassets/Screen1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.981",
+          "alpha" : "1.000",
+          "blue" : "0.042",
+          "green" : "0.572"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieExample/Images.xcassets/Screen2.colorset/Contents.json
+++ b/NatalieExample/NatalieExample/Images.xcassets/Screen2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.094",
+          "alpha" : "1.000",
+          "blue" : "0.846",
+          "green" : "0.500"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieExample/MainViewController.swift
+++ b/NatalieExample/NatalieExample/MainViewController.swift
@@ -30,13 +30,21 @@ class MainViewController: NTLViewController {
 
     override func prepare(for segue: NTLStoryboardSegue, sender: Any?) {
         if segue == MainViewController.Segue.screenOneSegue, let oneViewController = segue.destination as? ScreenOneViewController {
-            oneViewController.view.backgroundColor = NTLColor.yellow
+            if #available(OSX 10.13, iOS 11.0, tvOS 11.0, *) {
+                oneViewController.view.backgroundColor = NTLColor.Screen1 ?? .orange
+            } else {
+                oneViewController.view.backgroundColor = .orange
+            }
         } else if segue == MainViewController.Segue.screenOneSegueButton, let oneViewController = segue.destination as? ScreenOneViewController {
-            oneViewController.view.backgroundColor = NTLColor.brown
+                oneViewController.view.backgroundColor = .brown
         } else if segue == MainViewController.Segue.screenTwoSegue, let twoViewController = segue.destination as? ScreenTwoViewController {
-            twoViewController.view.backgroundColor = NTLColor.magenta
+            if #available(OSX 10.13, iOS 11.0, tvOS 11.0, *) {
+                twoViewController.view.backgroundColor = NTLColor.Screen2 ?? .blue
+            } else {
+                twoViewController.view.backgroundColor = .blue
+            }
         } else if segue == MainViewController.Segue.sceneOneGestureRecognizerSegue, let oneViewController = segue.destination as? ScreenOneViewController {
-            oneViewController.view.backgroundColor = NTLColor.green
+            oneViewController.view.backgroundColor = .green
         }
     }
 
@@ -58,7 +66,7 @@ class MainViewController: NTLViewController {
         open var destination: Any { return destinationController }
     }
     extension NSView {
-        open var backgroundColor: NSColor {
+       @IBInspectable open var backgroundColor: NSColor {
             get {
                 if let color: CGColor = self.layer?.backgroundColor {
                     return NSColor(cgColor: color)!

--- a/NatalieExample/NatalieExample/Storyboards.swift
+++ b/NatalieExample/NatalieExample/Storyboards.swift
@@ -62,6 +62,13 @@ struct Storyboards {
     }
 }
 
+// MARK: - Colors
+@available(iOS 11.0, *)
+extension UIColor {
+    static let Screen1 = UIColor(named: "Screen1")
+    static let Screen2 = UIColor(named: "Screen2")
+}
+
 // MARK: - ReusableKind
 enum ReusableKind: String, CustomStringConvertible {
     case tableViewCell = "tableViewCell"

--- a/NatalieExample/NatalieOSXExample/Assets.xcassets/Contents.json
+++ b/NatalieExample/NatalieOSXExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/NatalieExample/NatalieOSXExample/Assets.xcassets/Screen1.colorset/Contents.json
+++ b/NatalieExample/NatalieOSXExample/Assets.xcassets/Screen1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.981",
+          "alpha" : "1.000",
+          "blue" : "0.042",
+          "green" : "0.572"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieOSXExample/Assets.xcassets/Screen2.colorset/Contents.json
+++ b/NatalieExample/NatalieOSXExample/Assets.xcassets/Screen2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.094",
+          "alpha" : "1.000",
+          "blue" : "0.846",
+          "green" : "0.500"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieOSXExample/Base.lproj/Main.storyboard
+++ b/NatalieExample/NatalieOSXExample/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -669,6 +670,9 @@
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="bIY-2Z-duN"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -729,6 +733,9 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="dtE-q0-A3X" firstAttribute="leading" secondItem="6D8-4A-XEz" secondAttribute="leading" id="035-ma-dwg"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dtE-q0-A3X" secondAttribute="trailing" constant="20" symbolic="YES" id="4np-2X-vS2"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6D8-4A-XEz" secondAttribute="trailing" constant="20" symbolic="YES" id="DLx-jB-Q0y"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hAH-QC-9mD" secondAttribute="trailing" constant="20" symbolic="YES" id="N9q-Zw-igg"/>
                             <constraint firstItem="hAH-QC-9mD" firstAttribute="top" secondItem="dtE-q0-A3X" secondAttribute="bottom" constant="12" id="Q1l-6i-Kxk"/>
                             <constraint firstItem="6D8-4A-XEz" firstAttribute="top" secondItem="54q-h3-MlB" secondAttribute="bottom" constant="12" id="UqZ-Zn-D4w"/>
                             <constraint firstItem="hAH-QC-9mD" firstAttribute="leading" secondItem="dtE-q0-A3X" secondAttribute="leading" id="Urn-Ow-SqG"/>
@@ -736,6 +743,7 @@
                             <constraint firstItem="dtE-q0-A3X" firstAttribute="top" secondItem="6D8-4A-XEz" secondAttribute="bottom" constant="12" id="hzs-Lf-DAc"/>
                             <constraint firstItem="54q-h3-MlB" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="rP2-zv-Kt6"/>
                             <constraint firstItem="6D8-4A-XEz" firstAttribute="leading" secondItem="54q-h3-MlB" secondAttribute="leading" id="seJ-go-uJf"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="54q-h3-MlB" secondAttribute="trailing" constant="20" symbolic="YES" id="z4F-z6-6MO"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -751,7 +759,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fW3-iT-K5o">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fW3-iT-K5o">
                                 <rect key="frame" x="197" y="142" width="56" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Screen 1" id="PNY-1P-ROq">
                                     <font key="font" metaFont="system"/>
@@ -764,6 +772,11 @@
                             <constraint firstItem="fW3-iT-K5o" firstAttribute="centerY" secondItem="biF-Mf-L0Y" secondAttribute="centerY" id="IIg-zu-hFM"/>
                             <constraint firstItem="fW3-iT-K5o" firstAttribute="centerX" secondItem="biF-Mf-L0Y" secondAttribute="centerX" id="kTE-mF-pd0"/>
                         </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                <color key="value" name="Screen2"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
                     </view>
                 </viewController>
                 <customObject id="BRD-8X-Us9" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -778,7 +791,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="waE-AH-auY">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="waE-AH-auY">
                                 <rect key="frame" x="196" y="141" width="58" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Screen 2" id="MS2-ph-NVc">
                                     <font key="font" metaFont="system"/>
@@ -791,6 +804,11 @@
                             <constraint firstItem="waE-AH-auY" firstAttribute="centerY" secondItem="6Mh-x0-YJn" secondAttribute="centerY" id="Lu0-XL-MM1"/>
                             <constraint firstItem="waE-AH-auY" firstAttribute="centerX" secondItem="6Mh-x0-YJn" secondAttribute="centerX" id="P1o-co-PmH"/>
                         </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
+                                <color key="value" name="Screen1"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
                     </view>
                 </viewController>
                 <customObject id="mZQ-KA-Oog" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -798,6 +816,14 @@
             <point key="canvasLocation" x="312" y="1111"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="Screen1">
+            <color red="0.98100000620000005" green="0.57200002670000005" blue="0.041999999429999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Screen2">
+            <color red="0.093999996779999997" green="0.5" blue="0.84600001570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="rIw-t2-zng"/>
     </inferredMetricsTieBreakers>

--- a/NatalieExample/NatalieOSXExample/Storyboards.swift
+++ b/NatalieExample/NatalieOSXExample/Storyboards.swift
@@ -70,6 +70,13 @@ struct Storyboards {
     }
 }
 
+// MARK: - Colors
+@available(OSX 10.13, *)
+extension NSColor {
+    static let Screen1 = NSColor(named: NSColor.Name("Screen1"))
+    static let Screen2 = NSColor(named: NSColor.Name("Screen2"))
+}
+
 // MARK: - ReusableKind
 enum ReusableKind: String, CustomStringConvertible {
     case tableViewCell = "tableViewCell"

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -3,6 +3,10 @@
     {
       "idiom" : "tv",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/LaunchImage.launchimage/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/LaunchImage.launchimage/Contents.json
@@ -4,6 +4,13 @@
       "orientation" : "landscape",
       "idiom" : "tv",
       "extent" : "full-screen",
+      "minimum-system-version" : "11.0",
+      "scale" : "2x"
+    },
+    {
+      "orientation" : "landscape",
+      "idiom" : "tv",
+      "extent" : "full-screen",
       "minimum-system-version" : "9.0",
       "scale" : "1x"
     }

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/Screen1.colorset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/Screen1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "0.430",
+          "blue" : "0.097",
+          "green" : "0.705"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieTVOSExample/Assets.xcassets/Screen2.colorset/Contents.json
+++ b/NatalieExample/NatalieTVOSExample/Assets.xcassets/Screen2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.003",
+          "alpha" : "0.324",
+          "blue" : "0.063",
+          "green" : "0.832"
+        }
+      }
+    }
+  ]
+}

--- a/NatalieExample/NatalieTVOSExample/Base.lproj/Main.storyboard
+++ b/NatalieExample/NatalieTVOSExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Nqj-Ak-xlf">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13196" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Nqj-Ak-xlf">
     <device id="appleTV" orientation="landscape">
         <adaptation id="light"/>
     </device>
     <dependencies>
-        <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -97,7 +97,7 @@
                     <view key="view" contentMode="scaleToFill" id="1rL-E1-nAr">
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.0026687387394002523" green="0.83239556347150256" blue="0.062883904182744754" alpha="0.32386113556338031" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="Screen2"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6OC-38-w3V" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -115,7 +115,7 @@
                     <view key="view" contentMode="scaleToFill" id="98h-1H-jwY">
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="0.70510147739999995" blue="0.097436919639999994" alpha="0.43015514964788731" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="Screen1"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cjo-bd-Eeh" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -123,6 +123,14 @@
             <point key="canvasLocation" x="-4114" y="2849"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="Screen1">
+            <color red="0.98100000619888306" green="0.57200002670288086" blue="0.041999999433755875" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Screen2">
+            <color red="0.093999996781349182" green="0.5" blue="0.84600001573562622" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="7SE-5s-Bqc"/>
     </inferredMetricsTieBreakers>

--- a/NatalieExample/NatalieTVOSExample/Storyboards.swift
+++ b/NatalieExample/NatalieTVOSExample/Storyboards.swift
@@ -46,6 +46,13 @@ struct Storyboards {
     }
 }
 
+// MARK: - Colors
+@available(tvOS 11.0, *)
+extension UIColor {
+    static let Screen1 = UIColor(named: "Screen1")
+    static let Screen2 = UIColor(named: "Screen2")
+}
+
 // MARK: - ReusableKind
 enum ReusableKind: String, CustomStringConvertible {
     case tableViewCell = "tableViewCell"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ class MyCustomTableViewCell: UITableViewCell {
 }
 ```
 
+### Colors (iOS 11, macOS 10.13)
+
+Generate an `UIColor` (or `NSColor`) static property for each asset colors used in your storyboard.
+
 ## Installation
 
 #### Swift Package Manager

--- a/Sources/natalie/Color.swift
+++ b/Sources/natalie/Color.swift
@@ -1,0 +1,57 @@
+//
+//  Color.swift
+//  natalie
+//
+//  Created by phimage on 22/10/2017.
+//  Copyright © 2017 Marcin Krzyzanowski. All rights reserved.
+//
+
+class Color: XMLObject {
+
+    enum Catalog: String {
+        case system = "System"
+    }
+
+    enum ColorSpace: String {
+        case catalog
+        case custom
+    }
+
+    enum CustomColorSpace: String {
+        case sRGB
+    }
+
+    typealias Component = Double
+
+    lazy var key: String? = self.xml.element?.attribute(by: "key")?.text
+    lazy var assetName: String? = self.xml.element?.attribute(by: "name")?.text
+    lazy var catalog: Catalog? = self.xml.element?.attribute(by: "catalog")?.raw(Catalog.self)
+    lazy var colorSpace: ColorSpace? = self.xml.element?.attribute(by: "colorSpace")?.raw(ColorSpace.self)
+    lazy var customColorSpace: CustomColorSpace? = self.xml.element?.attribute(by: "customColorSpace")?.raw(CustomColorSpace.self)
+
+    lazy var red: Component? = self.xml.element?.attribute(by: "red")?.colorComponent
+    lazy var green: Component? = self.xml.element?.attribute(by: "green")?.colorComponent
+    lazy var blue: Component? = self.xml.element?.attribute(by: "blue")?.colorComponent
+    lazy var alpha: Component? = self.xml.element?.attribute(by: "alpha")?.colorComponent
+
+    lazy var components: (red: Component, blue: Component, green: Component, alpha: Component)? = {
+        guard let red = red, let blue = blue, let green = green, let alpha = alpha else {
+            return nil
+        }
+        return (red, green, blue, alpha)
+    }()
+
+    override init(xml: XMLIndexer) {
+        super.init(xml: xml)
+    }
+
+}
+
+extension XMLAttribute {
+    var colorComponent: Color.Component? {
+        return Color.Component(self.text)
+    }
+    func raw<R>(_ typeR: R.Type) -> R? where R: RawRepresentable, R.RawValue == String {
+        return typeR.init(rawValue: self.text)
+    }
+}

--- a/Sources/natalie/Helpers.swift
+++ b/Sources/natalie/Helpers.swift
@@ -46,3 +46,11 @@ func swiftRepresentation(for string: String, firstLetter: FirstLetterFormat = .n
     }
     return str
 }
+
+func initIdentifier(for identifierString: String, value: String) -> String {
+    if identifierString == "String" {
+        return "\"\(value)\""
+    } else {
+        return "\(identifierString)(\"\(value)\")"
+    }
+}

--- a/Sources/natalie/Natalie.swift
+++ b/Sources/natalie/Natalie.swift
@@ -97,7 +97,7 @@ struct Natalie {
             output += "@available(\(os.colorOS), *)\n"
             output += "extension \(os.colorType) {\n"
             for colorName in Set(colors) {
-                output += "    static let \(colorName) = \(os.colorType)(named: \(initIdentifier(for: os.colorNameType, value: colorName)))\n"
+                output += "    static let \(swiftRepresentation(for: colorName, firstLetter: .none)) = \(os.colorType)(named: \(initIdentifier(for: os.colorNameType, value: colorName)))\n"
             }
             output += "}\n"
             output += "\n"

--- a/Sources/natalie/Natalie.swift
+++ b/Sources/natalie/Natalie.swift
@@ -35,13 +35,13 @@ struct Natalie {
             let storyboardsForOS = storyboards.filter { $0.storyboard.os == os }
             if !storyboardsForOS.isEmpty {
 
-                if storyboardsForOS.count != storyboardFiles.count {
+                if storyboardsForOS.count != storyboards.count {
                     output += "#if os(\(os.rawValue))\n"
                 }
 
                 output += Natalie(storyboards: storyboardsForOS).process(os: os)
 
-                if storyboardsForOS.count != storyboardFiles.count {
+                if storyboardsForOS.count != storyboards.count {
                     output += "#endif\n"
                 }
             }
@@ -87,6 +87,21 @@ struct Natalie {
         }
         output += "}\n"
         output += "\n"
+        
+        let colors = storyboards
+            .flatMap { $0.storyboard.colors }
+            .filter { $0.catalog != .system }
+            .flatMap { $0.assetName }
+        if !colors.isEmpty {
+            output += "// MARK: - Colors\n"
+            output += "@available(\(os.colorOS), *)\n"
+            output += "extension \(os.colorType) {\n"
+            for colorName in Set(colors) {
+                output += "    static let \(colorName) = \(os.colorType)(named: \(initIdentifier(for: os.colorNameType, value: colorName)))\n"
+            }
+            output += "}\n"
+            output += "\n"
+        }
 
         output += "// MARK: - ReusableKind\n"
         output += "enum ReusableKind: String, CustomStringConvertible {\n"

--- a/Sources/natalie/OS.swift
+++ b/Sources/natalie/OS.swift
@@ -165,6 +165,35 @@ enum OS: String, CustomStringConvertible {
         }
     }
 
+    var colorType: String {
+        switch self {
+        case .iOS, .tvOS:
+            return "UIColor"
+        case .OSX:
+            return "NSColor"
+        }
+    }
+
+    var colorNameType: String {
+        switch self {
+        case .iOS, .tvOS:
+            return "String"
+        case .OSX:
+            return "NSColor.Name"
+        }
+    }
+
+    var colorOS: String {
+        switch self {
+        case .iOS:
+            return "iOS 11.0"
+        case .tvOS:
+            return "tvOS 11.0"
+        case .OSX:
+            return "OSX 10.13"
+        }
+    }
+
     var resuableViews: [String]? {
         switch self {
         case .iOS, .tvOS:

--- a/Sources/natalie/Storyboard+Natalie.swift
+++ b/Sources/natalie/Storyboard+Natalie.swift
@@ -58,14 +58,6 @@ extension Storyboard {
         return output
     }
 
-    func initIdentifier(for identifierString: String, value: String) -> String {
-        if identifierString == "String" {
-            return "\"\(value)\""
-        } else {
-            return "\(identifierString)(\"\(value)\")"
-        }
-    }
-
     func processViewControllers() -> String {
         var output = String()
 

--- a/Sources/natalie/Storyboard.swift
+++ b/Sources/natalie/Storyboard.swift
@@ -39,6 +39,13 @@ class Storyboard: XMLObject {
 
         return scenes.map { Scene(xml: $0) }
     }()
+    lazy var colors: [Color] = {
+        guard let colors = self.searchNamed(root: self.xml, name: "color") else {
+            return []
+        }
+
+        return colors.map { Color(xml: $0) }
+    }()
 
     lazy var customModules: Set<String> = Set(self.scenes.filter { $0.customModule != nil && $0.customModuleProvider == nil }.map { $0.customModule! })
 


### PR DESCRIPTION
only for iOS11,tvOS11,macOS10.13
https://littlebitesofcocoa.com/312-asset-catalog-improvements

Add a `Color` xml class to read color from storyboards

For each OS 
- I create an extension for the XXXColor class if there is at least one color
- and in there I create a constant variable for each asset color. An asset color have a name and are not a "System" one (so I have filtered system color like labelColor, etc...)

For other colors I think about adding it in controller.

See one of the `Storyboards.swift`file

I use the generated constant in demo app in `MainViewController.swift`

---

This new functionality of Xcode9/iOS11 seems to have some bugs

- In Xcode if we have multiple asset with same color name, sometimes the interface builder use a color from another asset.
  - workaround, use a shared asset between device and use idiom (not universal) if we want a different color by device
- When using an asset color in view background, the color set by `prepare(for segue:`seems to not be taken into account on iOS and tvOS.
  - maybe the color is set later in view loading process if this case. 
  - workaround: create a color variable in destination controller, and in viewDidAppear (and maybe in viewDidLoad) use the color to set as view background color

---

An other approach is to generate code from asset.
I want to make this generation optional later.

Maybe with a json config file (like #55), now with swift 4 this is easier
