### PR TITLE
Storyboard struct -instantiate* methods now return class types qualified by module

### DIFF
--- a/Sources/natalie/Natalie.swift
+++ b/Sources/natalie/Natalie.swift
@@ -24,6 +24,10 @@ struct Natalie {
     let storyboards: [StoryboardFile]
     let header = Header()
 
+    var storyboardCustomModules: Set<String> {
+        return Set(storyboards.lazy.flatMap { $0.storyboard.customModules })
+    }
+
     init(storyboards: [StoryboardFile]) {
         self.storyboards = storyboards
         assert(Set(storyboards.map { $0.storyboard.os }).count < 2)
@@ -54,7 +58,7 @@ struct Natalie {
 
         output += header.description
         output += "import \(os.framework)\n"
-        for module in Set(storyboards.lazy.flatMap { $0.storyboard.customModules }) {
+        for module in storyboardCustomModules {
             output += "import \(module)\n"
         }
         output += "\n"
@@ -87,7 +91,7 @@ struct Natalie {
         }
         output += "}\n"
         output += "\n"
-        
+
         let colors = storyboards
             .flatMap { $0.storyboard.colors }
             .filter { $0.catalog != .system }
@@ -297,8 +301,9 @@ struct Natalie {
             output += "}\n"
         }
 
+        let storyboardModules = storyboardCustomModules
         for file in storyboards {
-            output += file.storyboard.processViewControllers()
+            output += file.storyboard.processViewControllers(storyboardCustomModules: storyboardModules)
         }
 
         return output

--- a/Sources/natalie/Storyboard+Natalie.swift
+++ b/Sources/natalie/Storyboard+Natalie.swift
@@ -60,7 +60,7 @@ extension Storyboard {
         return output
     }
 
-    func processViewControllers() -> String {
+    func processViewControllers(storyboardCustomModules: Set<String>) -> String {
         var output = String()
 
         for scene in self.scenes {
@@ -89,9 +89,16 @@ extension Storyboard {
 
                         let initIdentifierString = initIdentifier(for: os.storyboardSceneIdentifierType, value: storyboardIdentifier)
 
-                        if viewController.customModule != nil {
+                        var isCurrentModule = false
+                        if let customModule = viewController.customModule {
+                            isCurrentModule = !storyboardCustomModules.contains(customModule)
+                        }
+
+                        if isCurrentModule {
+                            // Accessors for view controllers defined in the current module should be "internal".
                             output += "    var storyboardIdentifier: \(os.storyboardSceneIdentifierType)? { return \(initIdentifierString) }\n"
                         } else {
+                            // Accessors for view controllers in external modules (whether system or custom frameworks), should be marked public.
                             output += "    public var storyboardIdentifier: \(os.storyboardSceneIdentifierType)? { return \(initIdentifierString) }\n"
                         }
                         output += "    static var storyboardIdentifier: \(os.storyboardSceneIdentifierType)? { return \(initIdentifierString) }\n"

--- a/Sources/natalie/Storyboard+Natalie.swift
+++ b/Sources/natalie/Storyboard+Natalie.swift
@@ -42,7 +42,9 @@ extension Storyboard {
         }
         for scene in self.scenes {
             if let viewController = scene.viewController, let storyboardIdentifier = viewController.storyboardIdentifier {
-                guard let controllerClass = viewController.customClass ?? os.controllerType(for: viewController.name) else {
+                // The returned class could have the same name as the enclosing Storyboard struct,
+                // so we must qualify controllerClass with the module name.
+                guard let controllerClass = viewController.customClassWithModule ?? os.controllerType(for: viewController.name) else {
                     continue
                 }
 

--- a/Sources/natalie/Storyboard.swift
+++ b/Sources/natalie/Storyboard.swift
@@ -21,7 +21,9 @@ class Storyboard: XMLObject {
         if let initialViewControllerId = self.xml["document"].element?.attribute(by: "initialViewController")?.text,
             let xmlVC = self.searchById(id: initialViewControllerId) {
             let vc = ViewController(xml: xmlVC)
-            if let customClassName = vc.customClass {
+            // The initialViewController class could have the same name as the enclosing Storyboard struct,
+            // so we must qualify controllerClass with the module name.
+            if let customClassName = vc.customClassWithModule {
                 return customClassName
             }
 

--- a/Sources/natalie/ViewController.swift
+++ b/Sources/natalie/ViewController.swift
@@ -22,4 +22,15 @@ class ViewController: XMLObject {
         return nil
     }()
 
+    lazy var customClassWithModule: String? = {
+        if let className = self.customClass {
+            if let moduleName = self.customModule {
+                return "\(moduleName).\(className)"
+            } else {
+                return className
+            }
+        }
+        return nil
+    }()
+
 }


### PR DESCRIPTION
This fixes issue #114, where instantiating a view controller with the same name as the storyboard
would resolve to the Storyboard struct type, not the module's view controller type.