### PR TITLE
Dropping executable path before processing command line args.

### DIFF
--- a/Sources/natalie/main.swift
+++ b/Sources/natalie/main.swift
@@ -21,7 +21,7 @@ if CommandLine.arguments.count == 1 {
 var filePaths: [String] = []
 let storyboardSuffix = ".storyboard"
 
-for arg in CommandLine.arguments {
+for arg in CommandLine.arguments.dropFirst() {
     if arg == "--help" {
         printUsage()
         exit(0)


### PR DESCRIPTION
Very minor change, should have included this yesterday.